### PR TITLE
feat: adding chatgpt chats support

### DIFF
--- a/styles/chatgpt/chat/style.css
+++ b/styles/chatgpt/chat/style.css
@@ -1,0 +1,66 @@
+@media print {
+  .z-\[21\].flex-shrink-0.overflow-x-hidden.bg-token-sidebar-surface-primary.max-md\:\!w-0 {
+    display: none;
+  }
+
+  .draggable.no-draggable-children.sticky.top-0.p-3.mb-1\.5.flex.items-center.justify-between.z-10.h-header-height.font-semibold.bg-token-main-surface-primary.max-md\:hidden {
+    display: none;
+  }
+
+  .md\:pt-0.dark\:border-white\/20.md\:border-transparent.md\:dark\:border-transparent.w-full.isolate.has-\[\[data-has-thread-error\]\]\:\[box-shadow\:var\(--sharp-edge-bottom-shadow\)\].has-\[\[data-has-thread-error\]\]\:pt-2 {
+    display: none;
+  }
+
+  .mx-auto.flex.flex-1.gap-4.text-base.md\:gap-5.lg\:gap-6.md\:max-w-3xl.lg\:max-w-\[40rem\].xl\:max-w-\[48rem\] {
+    max-width: 100vw;
+  }
+
+  .overflow-y-auto.p-4 {
+    overflow-y: initial;
+    overflow-wrap: anywhere;
+  }
+
+  main.relative.h-full.w-full.flex-1.overflow-auto.transition-width {
+    overflow: initial;
+  }
+
+  .relative.flex.h-full.max-w-full.flex-1.flex-col.overflow-hidden {
+    overflow: initial;
+  }
+
+  .flex.h-full.w-full.flex-col {
+    height: initial;
+    width: initial;
+  }
+
+  pre.\!overflow-visible {
+    overflow: initial !important;
+    overflow-wrap: anywhere;
+  }
+
+  .flex.w-full.flex-col.gap-1.empty\:hidden.first\:pt-\[3px\] {
+    width: auto;
+    overflow-wrap: anywhere;
+  }
+
+  .min-h-8.text-message.flex.w-full.flex-col.items-end.gap-2.whitespace-normal.break-words.text-start.\[\.text-message\+\&\]\:mt-5 {
+    max-width: 100vw;
+    overflow-wrap: normal;
+  }
+
+  code.\!whitespace-pre.language-markdown {
+    text-wrap-mode: wrap !important;
+  }
+
+  .group\/conversation-turn.relative.flex.w-full.min-w-0.flex-col.agent-turn.\@xs\/thread\:px-0.\@sm\/thread\:px-1\.5.\@md\/thread\:px-4 {
+    padding: 0;
+  }
+
+  .min-h-8.text-message.flex.w-full.flex-col.items-end.gap-2.whitespace-normal.break-words.text-start.\[\.text-message\+\&\]\:mt-5[data-message-author-role="user"] {
+    align-items: flex-end;
+  }
+
+  .min-h-8.text-message.flex.w-full.flex-col.items-end.gap-2.whitespace-normal.break-words.text-start.\[\.text-message\+\&\]\:mt-5 {
+    align-items: initial;
+  }
+}


### PR DESCRIPTION
Adding some basic styles to be able to print ChatGPT conversation. Useful for complex conversations that you want to write notes on.

Before:
![2025-02-15 17 47 12](https://github.com/user-attachments/assets/7f367c88-6410-4f49-b2e5-c0ea17508944)
[chatgpt-before.pdf](https://github.com/user-attachments/files/18812883/chatgpt-before.pdf)

After:
![2025-02-15 17 47 53](https://github.com/user-attachments/assets/6f9bbf7c-5199-4c69-b18a-4e945e6ed683)
[chatgpt-after.pdf](https://github.com/user-attachments/files/18812882/chatgpt-after.pdf)